### PR TITLE
ink remove top-level await call for pkg/esbuild/rollup/node sea forma…

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"eslint-plugin-react": "^7.37.5",
 		"eslint-plugin-react-hooks": "^5.0.0",
 		"ms": "^2.1.3",
-		"node-pty": "^1.0.0",
+		"node-pty": "^1.1.0-beta34",
 		"p-queue": "^8.0.0",
 		"prettier": "^3.3.3",
 		"react": "^19.1.0",

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,4 +1,5 @@
-import Yoga, {type Node as YogaNode} from 'yoga-layout';
+import type { Node as YogaNode } from './yoga-proxy.js';
+import Yoga from './yoga-proxy.js';
 import measureText from './measure-text.js';
 import {type Styles} from './styles.js';
 import wrapText from './wrap-text.js';

--- a/src/get-max-width.ts
+++ b/src/get-max-width.ts
@@ -1,4 +1,5 @@
-import Yoga, {type Node as YogaNode} from 'yoga-layout';
+import type { Node as YogaNode } from './yoga-proxy.js';
+import Yoga from './yoga-proxy.js';
 
 const getMaxWidth = (yogaNode: YogaNode) => {
 	return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,3 +25,4 @@ export {default as useFocus} from './hooks/use-focus.js';
 export {default as useFocusManager} from './hooks/use-focus-manager.js';
 export {default as measureElement} from './measure-element.js';
 export type {DOMElement} from './dom.js';
+export { loadGlobalYoga } from './yoga-proxy.js';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -8,7 +8,7 @@ import signalExit from 'signal-exit';
 import patchConsole from 'patch-console';
 import {LegacyRoot} from 'react-reconciler/constants.js';
 import {type FiberRoot} from 'react-reconciler';
-import Yoga from 'yoga-layout';
+import Yoga from './yoga-proxy.js';
 import reconciler from './reconciler.js';
 import render from './renderer.js';
 import * as dom from './dom.js';

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -4,7 +4,8 @@ import {
 	DefaultEventPriority,
 	NoEventPriority,
 } from 'react-reconciler/constants.js';
-import Yoga, {type Node as YogaNode} from 'yoga-layout';
+import type { Node as YogaNode } from './yoga-proxy.js';
+import Yoga from './yoga-proxy.js';
 import {createContext} from 'react';
 import {
 	createTextNode,
@@ -27,6 +28,7 @@ import {type OutputTransformer} from './render-node-to-output.js';
 // accidentally breaking other third-party code.
 // See https://github.com/vadimdemedes/ink/issues/384
 if (process.env['DEV'] === 'true') {
+	(async () => {
 	try {
 		await import('./devtools.js');
 	} catch (error: any) {
@@ -46,6 +48,7 @@ $ npm install --save-dev react-devtools-core
 			throw error;
 		}
 	}
+	})();
 }
 
 type AnyObject = Record<string, unknown>;

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -1,6 +1,6 @@
 import widestLine from 'widest-line';
 import indentString from 'indent-string';
-import Yoga from 'yoga-layout';
+import Yoga from './yoga-proxy.js';
 import wrapText from './wrap-text.js';
 import getMaxWidth from './get-max-width.js';
 import squashTextNodes from './squash-text-nodes.js';

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,7 +2,8 @@
 import {type Boxes, type BoxStyle} from 'cli-boxes';
 import {type LiteralUnion} from 'type-fest';
 import {type ForegroundColorName} from 'ansi-styles'; // Note: We import directly from `ansi-styles` to avoid a bug in TypeScript.
-import Yoga, {type Node as YogaNode} from 'yoga-layout';
+import type { Node as YogaNode } from './yoga-proxy.js';
+import Yoga from './yoga-proxy.js';
 
 export type Styles = {
 	readonly textWrap?:

--- a/src/yoga-proxy.ts
+++ b/src/yoga-proxy.ts
@@ -1,0 +1,27 @@
+import { loadYoga } from 'yoga-layout/load';
+import type { Yoga as YogaType } from 'yoga-layout/load';
+export * from 'yoga-layout/load';
+
+const YogaProxy = new Proxy({} as YogaType, {
+  get(target: YogaType, prop: keyof YogaType) {
+    if (prop in target) {
+      return target[prop];
+    }
+    return (globalThis as any).yoga_instance[prop];
+  },
+
+  set(target: YogaType, prop: keyof YogaType, value: any) {
+    ((globalThis as any).yoga_instance as any)[prop] = value;
+    target[prop] = value as never;
+    return true;
+  }
+});
+
+export const loadGlobalYoga = async () => {
+  if (!(globalThis as any).yoga_instance) {
+    (globalThis as any).yoga_instance = await loadYoga();
+  }
+  return (globalThis as any).yoga_instance;
+};
+
+export default YogaProxy;


### PR DESCRIPTION
ink remove top-level await call for pkg/esbuild/rollup/node sea format = commonjs package

This pull request introduces a significant refactor to replace direct imports of the `yoga-layout` library with a new proxy-based implementation (`yoga-proxy.js`). This change centralizes the handling of the Yoga library, allowing for dynamic loading and global management of the Yoga instance. Additionally, the `node-pty` dependency has been updated to a beta version. Below are the key changes grouped by theme:

### Yoga Proxy Refactor:
* Introduced `yoga-proxy.js` to provide a proxy-based interface for the Yoga library, enabling dynamic loading of the Yoga instance via the `loadGlobalYoga` function. (`src/yoga-proxy.ts`, [src/yoga-proxy.tsR1-R27](diffhunk://#diff-8bde121d49b6c849d93faf9260439a34d0664db6bbc4a8424445cd49316fa73cR1-R27))
* Replaced all direct imports of `yoga-layout` with imports from the new `yoga-proxy.js` across multiple files, including `src/dom.ts`, `src/get-max-width.ts`, `src/ink.tsx`, `src/reconciler.ts`, `src/render-node-to-output.ts`, and `src/styles.ts`. [[1]](diffhunk://#diff-4597831ddb5b6e7438ce1c37a074ac5d684138a5fc14a6cde1dd13565fa026b3L1-R2) [[2]](diffhunk://#diff-3f384ca426b33824c3c3f5d846dab5db14f080854939ffca02703d9d81f982efL1-R2) [[3]](diffhunk://#diff-6043b94733c1d06046416bff01d353b3fbbffbf90543b98eb6d0b861182d3924L11-R11) [[4]](diffhunk://#diff-92cf748778b8e4481e8c7e0e81785c68bf04046c7b16192b7b4c185c58e9e2cbL7-R8) [[5]](diffhunk://#diff-3deb93a892020e339531ae9068c70d3d3bdb485b452b176a0c0e9396bf8d9f06L3-R3) [[6]](diffhunk://#diff-b42ea201ee4847a59cf8b6173f170460266e26bf9fb7052ad9f4247429bb27f2L5-R6)
* Exported the `loadGlobalYoga` function from `yoga-proxy.js` in `src/index.ts` to make it accessible for external usage.

### Dependency Update:
* Updated the `node-pty` dependency in `package.json` from version `^1.0.0` to `^1.1.0-beta34` to fix windows gyp compile.

### Development Enhancements:
* Added an asynchronous block to conditionally load `devtools.js` during development mode. This ensures that the devtools are only loaded when the `DEV` environment variable is set to `true`. (`src/reconciler.ts`, [[1]](diffhunk://#diff-92cf748778b8e4481e8c7e0e81785c68bf04046c7b16192b7b4c185c58e9e2cbR31) [[2]](diffhunk://#diff-92cf748778b8e4481e8c7e0e81785c68bf04046c7b16192b7b4c185c58e9e2cbR51))