### PR TITLE
docs(readme): remove duplicate important notice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,8 +70,6 @@ If you encounter issues when using bundling tools (like Webpack, Rollup, esbuild
 
 *** IMPORTANT ***
 
-*** IMPORTANT ***
-
 ```sh
 npm install ink@npm:@heisir/ink react
 ```


### PR DESCRIPTION
## What Changed
从 readme.md 文件中移除了重复的 "*** IMPORTANT ***" 行。

## Why
在文档中存在重复的重要提示信息，这可能会对用户造成混淆。清理重复内容有助于提高文档的可读性和专业性。

## How to Test
1. 查看更新后的 readme.md 文件
2. 确认只有一行 "*** IMPORTANT ***" 显示
3. 验证文档格式和布局是否正确显示